### PR TITLE
return a string ID from getId

### DIFF
--- a/src/helpers/get-id.js
+++ b/src/helpers/get-id.js
@@ -1,6 +1,6 @@
 
 module.exports = getId;
 
-function getId (rec) {
-  return 'id' in rec ? rec.id : rec._id;
+function getId(rec) {
+  return 'id' in rec ? `${rec.id}` : `${rec._id}`;
 }


### PR DESCRIPTION
closes #9

### Summary
Fixes #9, where the ID's of the current user and the user being affected are not compared correctly. 

This should fix the issue anywhere that getId is used. 

### Question
Is there a way to write tests for this change? It seems like a fringe case with MongoDB ObjectID's or something.